### PR TITLE
fix: Move Rollup native dependency to production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
+        "@rollup/rollup-linux-x64-gnu": "^4.20.0",
         "@tanstack/react-query": "^5.56.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -62,7 +63,6 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250529.0",
         "@eslint/js": "^9.9.0",
-        "@rollup/rollup-linux-x64-gnu": "^4.20.0",
         "@tailwindcss/typography": "^0.5.15",
         "@types/node": "^22.15.24",
         "@types/react": "^18.3.3",
@@ -1960,7 +1960,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "os": [
         "linux"
       ]

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.25.36"
+    "zod": "^3.25.36",
+    "@rollup/rollup-linux-x64-gnu": "^4.20.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250529.0",
@@ -84,7 +85,6 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1",
-    "@rollup/rollup-linux-x64-gnu": "^4.20.0"
+    "vite": "^5.4.1"
   }
 }


### PR DESCRIPTION
Moves `@rollup/rollup-linux-x64-gnu` from `devDependencies` to `dependencies` to potentially resolve a Cloudflare Pages build issue.

The build error `Cannot find module '@rollup/rollup-linux-x64-gnu'` persisted even after adding the package to `devDependencies`. Treating it as a production dependency might ensure its availability and correct linkage in the Cloudflare build environment.

- Moved `@rollup/rollup-linux-x64-gnu` from `devDependencies` to `dependencies` in `package.json`.
- Updated `package-lock.json` by running `npm install`.