### PR TITLE
fix: Point WaitlistCTA form to /api/waitlist endpoint

### DIFF
--- a/src/components/WaitlistCTA.tsx
+++ b/src/components/WaitlistCTA.tsx
@@ -19,7 +19,7 @@ const WaitlistCTA: React.FC = () => {
       emailSchema.parse(email);
       
       setIsSubmitting(true);
-      const response = await fetch(`${API_URL}/api/early-access`, {
+      const response = await fetch(`${API_URL}/api/waitlist`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
The WaitlistCTA component was previously making a POST request to `/api/early-access`. This commit updates the fetch call to target `/api/waitlist`, which is the correct endpoint for the Cloudflare Function created to handle waitlist submissions.

The use of `VITE_API_URL` with a fallback to an empty string allows this to work correctly with a relative path in the deployed Cloudflare Pages environment without `VITE_API_URL` being explicitly set.