### PR TITLE
fix: Ensure _routes.json is copied to output directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && cp public/_routes.json dist/_routes.json",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",


### PR DESCRIPTION
Updates the build script in `package.json` to explicitly copy `public/_routes.json` to `dist/_routes.json` after the `vite build` command completes.

This is to ensure that Cloudflare Pages can correctly find and process the routing rules for functions, which is necessary for enabling function-based features like environment variables and for API calls to the function to succeed.

This change aims to address issues where the function might not have been recognized by Cloudflare Pages despite correct configurations in `wrangler.jsonc` and the presence of the function code.