### PR TITLE
chore: Add a command to the build script for diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && cp public/_routes.json dist/_routes.json",
+    "build": "vite build && cp public/_routes.json dist/_routes.json && ls -la dist/",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",


### PR DESCRIPTION
This change appends a command to the `build` script in `package.json` that will list the contents of the `dist` directory. This is for diagnostic purposes, to see the contents of the `dist` directory at the end of the Cloudflare Pages build process.

The output of this command in the build logs will help you verify the presence and structure of files, particularly `_routes.json`, which is crucial for function routing and detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build process to display the contents of the output directory after building and copying files. This does not affect the application’s functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->